### PR TITLE
Fix path parameters

### DIFF
--- a/lib/generate-swagger.js
+++ b/lib/generate-swagger.js
@@ -149,11 +149,12 @@ const generateRoutes = (routeDefinitions, existingTags) => {
 
   for (let method of Object.keys(routeDefinitions)) {
     for (let path of Object.keys(routeDefinitions[method])) {
+      const swaggerPath = path.replace(/\/:([a-zA-Z]*)/g, '/{$1}')
       let route = routeDefinitions[method][path]
-      if (!paths[path]) {
-        paths[path] = {}
+      if (!paths[swaggerPath]) {
+        paths[swaggerPath] = {}
       }
-      paths[path][method] = {
+      paths[swaggerPath][method] = {
         tags: route.tags || [],
         summary: route.summary || '',
         description: route.description || '',

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -414,7 +414,7 @@ describe('router', () => {
         produces: ['application/json'],
         schemes: ['https'],
         paths: {
-          '/api/something/:id': {
+          '/api/something/{id}': {
             put: {
               tags: ['Something'],
               summary: 'This route is about something',


### PR DESCRIPTION
express is `:id` wheras swagger is `{id}`

this will allow us to use swagger ui with actual input